### PR TITLE
Make all 3 arrows shot from the Tri-Bow of the same arrow type.

### DIFF
--- a/src/main/java/twilightforest/item/ItemTFTripleBow.java
+++ b/src/main/java/twilightforest/item/ItemTFTripleBow.java
@@ -50,13 +50,13 @@ public class ItemTFTripleBow extends ItemTFBowBase {
 						entityarrow.shoot(entityplayer, entityplayer.rotationPitch, entityplayer.rotationYaw, 0.0F, f * 3.0F, 1.0F);
 
 						// other arrows with slight deviation
-						EntityArrow entityarrow1 = new EntityTippedArrow(worldIn, entityLiving);
+						EntityArrow entityarrow1 = itemarrow.createArrow(worldIn, itemstack, entityplayer);
 						entityarrow1.shoot(entityLiving, entityLiving.rotationPitch, entityLiving.rotationYaw, 0, f * 2, 1);
 						entityarrow1.motionY += 0.007499999832361937D * 20F;
 						entityarrow1.posY += 0.025F;
 						entityarrow1.pickupStatus = EntityArrow.PickupStatus.CREATIVE_ONLY;
 
-						EntityArrow entityarrow2 = new EntityTippedArrow(worldIn, entityLiving);
+						EntityArrow entityarrow2 = itemarrow.createArrow(worldIn, itemstack, entityplayer);
 						entityarrow2.shoot(entityLiving, entityLiving.rotationPitch, entityLiving.rotationYaw, 0, f * 2, 1);
 						entityarrow2.motionY -= 0.007499999832361937D * 20F;
 						entityarrow2.posY -= 0.025F;


### PR DESCRIPTION
Don't know if it was intentional to have the additional arrows just be ordinary, but with this change firing from a Tri-Bow, a spectral arrow, tipped arrow, or any item that extends ItemArrow, will shoot 3 of that type.