### PR TITLE
Fix graveyard rare loot roll

### DIFF
--- a/src/main/resources/assets/twilightforest/loot_tables/structures/graveyard/rare.json
+++ b/src/main/resources/assets/twilightforest/loot_tables/structures/graveyard/rare.json
@@ -5,7 +5,7 @@
 	"entries": [
 	  {
 		"type": "item",
-		"name": "twilightforest:golden_apple"
+		"name": "minecraft:golden_apple"
 	  },
 	  {
 		"type": "item",


### PR DESCRIPTION
Golden apple used TF namespace instead of MC