### PR TITLE
Alpha Yeti Trophy

### DIFF
--- a/src/main/java/twilightforest/TFEventListener.java
+++ b/src/main/java/twilightforest/TFEventListener.java
@@ -293,7 +293,7 @@ public class TFEventListener {
 			case QUEST_RAM: return TFFeature.QUEST_GROVE;
 			case FINAL_BOSS: return TFFeature.FINAL_CASTLE;
 			case MINOSHROOM: return TFFeature.LABYRINTH;
-			case ALPHA_YETI: return TFFeature.YETI_CAVE;
+			case YETI_ALPHA: return TFFeature.YETI_CAVE;
 			case SNOW_QUEEN: return TFFeature.ICE_TOWER;
 			case KNIGHT_PHANTOM: return TFFeature.KNIGHT_STRONGHOLD;
 			default: return null;

--- a/src/main/java/twilightforest/block/BlockTFTrophy.java
+++ b/src/main/java/twilightforest/block/BlockTFTrophy.java
@@ -110,6 +110,10 @@ public class BlockTFTrophy extends BlockSkull implements ModelRegisterCallback, 
 					sound = SoundEvents.ENTITY_COW_AMBIENT;
 					volume = 0.5F;
 					break;
+				case YETI_ALPHA:
+					sound = TFSounds.ALPHAYETI_GROWL;
+					volume = 0.5F;
+					break;
 				case QUEST_RAM:
 					sound = SoundEvents.ENTITY_SHEEP_AMBIENT;
 					break;

--- a/src/main/java/twilightforest/client/model/entity/ModelTFYetiAlphaTrophy.java
+++ b/src/main/java/twilightforest/client/model/entity/ModelTFYetiAlphaTrophy.java
@@ -7,13 +7,13 @@ import net.minecraft.util.math.MathHelper;
 import twilightforest.entity.boss.EntityTFYetiAlpha;
 
 
-public class ModelTFYetiAlpha extends ModelBiped {
+public class ModelTFYetiAlphaTrophy extends ModelBiped {
 
 	public ModelRenderer mouth;
 	public ModelRenderer leftEye;
 	public ModelRenderer rightEye;
 
-	public ModelTFYetiAlpha() {
+	public ModelTFYetiAlphaTrophy() {
 		super();
 
 		this.textureWidth = 256;
@@ -26,7 +26,7 @@ public class ModelTFYetiAlpha extends ModelBiped {
 		this.bipedHeadwear.addBox(-4.0F, -8.0F, -4.0F, 0, 0, 0);
 
 		this.bipedBody = new ModelRenderer(this, 80, 0);
-		this.bipedBody.addBox(-24.0F, -60.0F, -18.0F, 48, 72, 36);
+		this.bipedBody.addBox(-24.0F, -60.0F, -18.0F, 48, 56, 36);
 		this.bipedBody.setRotationPoint(0.0F, -6.0F, 0.0F);
 
 		this.mouth = new ModelRenderer(this, 121, 50);
@@ -43,29 +43,6 @@ public class ModelTFYetiAlpha extends ModelBiped {
 		this.leftEye.addBox(-6.0F, -6.0F, -1.5F, 12, 12, 2);
 		this.leftEye.setRotationPoint(14.0F, -50.0F, -18.0F);
 		this.bipedBody.addChild(leftEye);
-
-		this.bipedRightArm = new ModelRenderer(this, 0, 0);
-		this.bipedRightArm.addBox(-15.0F, -6.0F, -8.0F, 16, 48, 16);
-		this.bipedRightArm.setRotationPoint(-25.0F, -26.0F, 0.0F);
-
-		this.bipedBody.addChild(this.bipedRightArm);
-
-		this.bipedLeftArm = new ModelRenderer(this, 0, 0);
-		this.bipedLeftArm.mirror = true;
-		this.bipedLeftArm.addBox(-1.0F, -6.0F, -8.0F, 16, 48, 16);
-		this.bipedLeftArm.setRotationPoint(25.0F, -26.0F, 0.0F);
-
-		this.bipedBody.addChild(this.bipedLeftArm);
-
-
-		this.bipedRightLeg = new ModelRenderer(this, 0, 66);
-		this.bipedRightLeg.addBox(-10.0F, 0.0F, -10.0F, 20, 20, 20);
-		this.bipedRightLeg.setRotationPoint(-13.5F, 4.0F, 0.0F);
-
-		this.bipedLeftLeg = new ModelRenderer(this, 0, 66);
-		this.bipedLeftLeg.mirror = true;
-		this.bipedLeftLeg.addBox(-10.0F, 0.0F, -10.0F, 20, 20, 20);
-		this.bipedLeftLeg.setRotationPoint(13.5F, 4.0F, 0.0F);
 
 		addPairHorns(-58.0F, 35F);
 		addPairHorns(-46.0F, 15F);
@@ -123,8 +100,6 @@ public class ModelTFYetiAlpha extends ModelBiped {
 		this.setRotationAngles(limbSwing, limbSwingAmount, ageInTicks, netHeadYaw, headPitch, scale, entity);
 
 		this.bipedBody.render(scale);
-		this.bipedRightLeg.render(scale);
-		this.bipedLeftLeg.render(scale);
 	}
 
 	/**

--- a/src/main/java/twilightforest/client/renderer/tileentity/TileEntityTFTrophyRenderer.java
+++ b/src/main/java/twilightforest/client/renderer/tileentity/TileEntityTFTrophyRenderer.java
@@ -29,6 +29,7 @@ import twilightforest.client.model.entity.ModelTFNaga;
 import twilightforest.client.model.armor.ModelTFPhantomArmor;
 import twilightforest.client.model.entity.ModelTFQuestRam;
 import twilightforest.client.model.entity.ModelTFSnowQueen;
+import twilightforest.client.model.entity.ModelTFYetiAlphaTrophy;
 import twilightforest.client.model.entity.ModelTFTowerBoss;
 import twilightforest.tileentity.TileEntityTFTrophy;
 
@@ -52,6 +53,9 @@ public class TileEntityTFTrophyRenderer extends TileEntitySpecialRenderer<TileEn
 
 	private final ModelTFSnowQueen snowQueenModel = new ModelTFSnowQueen();
 	private static final ResourceLocation textureLocSnowQueen = TwilightForestMod.getModelTexture("snowqueen.png");
+
+	private final ModelTFYetiAlphaTrophy yetiAlphaModel = new ModelTFYetiAlphaTrophy();
+	private static final ResourceLocation textureLocYetiAlpha = TwilightForestMod.getModelTexture("yetialpha.png");
 
 	private final ModelTFMinoshroom minoshroomModel = new ModelTFMinoshroom();
 	private static final ResourceLocation textureLocMinoshroom = TwilightForestMod.getModelTexture("minoshroomtaur.png");
@@ -201,6 +205,9 @@ public class TileEntityTFTrophyRenderer extends TileEntitySpecialRenderer<TileEn
 			case KNIGHT_PHANTOM:
 				renderKnightPhantomHead(rotation, onGround);
 				break;
+			case YETI_ALPHA:
+				renderYetiAlphaHead(rotation, onGround);
+				break;
 			case QUEST_RAM:
 				renderQuestRamHead(rotation, onGround);
 				break;
@@ -326,6 +333,25 @@ public class TileEntityTFTrophyRenderer extends TileEntitySpecialRenderer<TileEn
 		snowQueenModel.bipedHead.render(0.0625F);
 		snowQueenModel.bipedHeadwear.render(0.0625F);
 	}
+
+	private void renderYetiAlphaHead(float rotation, boolean onGround) {
+		GlStateManager.translate(0, -0.3, 0);
+
+		GlStateManager.scale(0.2f, 0.2f, 0.2f);
+
+		this.bindTexture(textureLocYetiAlpha);
+
+		GlStateManager.scale(1f, -1f, -1f);
+
+		// we seem to be getting a 180 degree rotation here
+		GlStateManager.rotate(rotation, 0F, 1F, 0F);
+		GlStateManager.rotate(180F, 0F, 1F, 0F);
+
+		GlStateManager.translate(0, onGround ? 1.5F : 1.25F, onGround ? 0F : 0.24F);
+
+		yetiAlphaModel.bipedBody.render(0.0625F);
+	}
+
 
 	private void renderMinoshroomHead(float rotation, boolean onGround) {
 		GlStateManager.translate(0, 1, 0);

--- a/src/main/java/twilightforest/entity/boss/EntityTFYetiAlpha.java
+++ b/src/main/java/twilightforest/entity/boss/EntityTFYetiAlpha.java
@@ -108,7 +108,7 @@ public class EntityTFYetiAlpha extends EntityMob implements IRangedAttackMob, IH
 		super.entityInit();
 		dataManager.register(RAMPAGE_FLAG, (byte) 0);
 		dataManager.register(TIRED_FLAG, (byte) 0);
-		IBossCapability.initBoss(this, BossVariant.ALPHA_YETI);
+		IBossCapability.initBoss(this, BossVariant.YETI_ALPHA);
 	}
 
 	@Override
@@ -340,7 +340,7 @@ public class EntityTFYetiAlpha extends EntityMob implements IRangedAttackMob, IH
 	@Override
 	protected void despawnEntity() {
 		if (world.getDifficulty() == EnumDifficulty.PEACEFUL) {
-			if (hasHome()) world.setBlockState(getHomePosition(), TFBlocks.boss_spawner.getDefaultState().withProperty(BlockTFBossSpawner.VARIANT, BossVariant.ALPHA_YETI));
+			if (hasHome()) world.setBlockState(getHomePosition(), TFBlocks.boss_spawner.getDefaultState().withProperty(BlockTFBossSpawner.VARIANT, BossVariant.YETI_ALPHA));
 			this.setDead();
 		} else super.despawnEntity();
 	}

--- a/src/main/java/twilightforest/enums/BossVariant.java
+++ b/src/main/java/twilightforest/enums/BossVariant.java
@@ -25,7 +25,7 @@ public enum BossVariant implements IStringSerializable {
 	KNIGHT_PHANTOM(TrophyType.IRON    , TileEntityTFKnightPhantomsSpawner::new),
 	SNOW_QUEEN    (TrophyType.GOLD    , TileEntityTFSnowQueenSpawner::new),
 	MINOSHROOM    (TrophyType.IRON    , TileEntityTFMinoshroomSpawner::new),
-	ALPHA_YETI    (TrophyType.IRON    , TileEntityTFAlphaYetiSpawner::new),
+	YETI_ALPHA    (TrophyType.IRON    , TileEntityTFAlphaYetiSpawner::new),
 	QUEST_RAM     (TrophyType.IRONWOOD, null),
 	FINAL_BOSS    (TrophyType.GOLD    , TileEntityTFFinalBossSpawner::new);
 

--- a/src/main/java/twilightforest/item/ItemTFTrophy.java
+++ b/src/main/java/twilightforest/item/ItemTFTrophy.java
@@ -46,7 +46,8 @@ public class ItemTFTrophy extends ItemTF {
 	public void getSubItems(CreativeTabs tab, NonNullList<ItemStack> list) {
 		if (isInCreativeTab(tab)) {
 			for (BossVariant v : BossVariant.values()) {
-				if (v != BossVariant.ALPHA_YETI && v != BossVariant.FINAL_BOSS) {
+				//if (v != BossVariant.ALPHA_YETI 
+				if (v != BossVariant.FINAL_BOSS) {
 					list.add(new ItemStack(this, 1, v.ordinal()));
 				}
 			}
@@ -153,10 +154,10 @@ public class ItemTFTrophy extends ItemTF {
 		ClientRegistry.bindTileEntitySpecialRenderer(TileEntityTFTrophyRenderer.DummyTile.class, tesr);
 
 		for (BossVariant variant : BossVariant.values()) {
-			if (variant != BossVariant.ALPHA_YETI) {
+			// if (variant != BossVariant.ALPHA_YETI) {
 				ModelLoader.setCustomModelResourceLocation(this, variant.ordinal(), itemModelLocation);
 				ForgeHooksClient.registerTESRItemStack(this, variant.ordinal(), TileEntityTFTrophyRenderer.DummyTile.class);
-			}
+			// }
 		}
 
 		ModelBakery.registerItemVariants(this,

--- a/src/main/java/twilightforest/structures/ComponentTFYetiCave.java
+++ b/src/main/java/twilightforest/structures/ComponentTFYetiCave.java
@@ -76,7 +76,7 @@ public class ComponentTFYetiCave extends ComponentTFHollowHill {
 		}
 
 		// spawn alpha yeti
-		final IBlockState yetiSpawner = TFBlocks.boss_spawner.getDefaultState().withProperty(BlockTFBossSpawner.VARIANT, BossVariant.ALPHA_YETI);
+		final IBlockState yetiSpawner = TFBlocks.boss_spawner.getDefaultState().withProperty(BlockTFBossSpawner.VARIANT, BossVariant.YETI_ALPHA);
 		setBlockStateRotated(world, yetiSpawner, radius, 1, radius, Rotation.NONE, sbb);
 
 		return true;

--- a/src/main/java/twilightforest/tileentity/spawner/TileEntityTFAlphaYetiSpawner.java
+++ b/src/main/java/twilightforest/tileentity/spawner/TileEntityTFAlphaYetiSpawner.java
@@ -8,7 +8,7 @@ import twilightforest.enums.BossVariant;
 public class TileEntityTFAlphaYetiSpawner extends TileEntityTFBossSpawner {
 
 	public TileEntityTFAlphaYetiSpawner() {
-		super(EntityList.getKey(EntityTFYetiAlpha.class), BossVariant.ALPHA_YETI);
+		super(EntityList.getKey(EntityTFYetiAlpha.class), BossVariant.YETI_ALPHA);
 	}
 
 	@Override

--- a/src/main/resources/assets/twilightforest/advancements/progress_yeti.json
+++ b/src/main/resources/assets/twilightforest/advancements/progress_yeti.json
@@ -1,7 +1,8 @@
 {
   "display": {
     "icon": {
-      "item": "twilightforest:alpha_fur"
+      "item": "twilightforest:trophy",
+      "data": 7
     },
     "title": {
       "translate": "advancement.twilightforest.progress_yeti"

--- a/src/main/resources/assets/twilightforest/loot_tables/entities/yeti_alpha.json
+++ b/src/main/resources/assets/twilightforest/loot_tables/entities/yeti_alpha.json
@@ -24,6 +24,14 @@
         ]
       }]
     }, {
+      "name": "trophy",
+      "rolls": 1,
+      "entries": [{
+        "type": "item",
+        "name": "twilightforest:trophy",
+        "functions": [{ "function": "set_data", "data": 7 }]
+      }]
+    },  {
       "name": "shader",
       "rolls": 1,
       "conditions": [{ "condition": "twilightforest:mod_exists", "mod_id": "immersiveengineering" }],

--- a/src/main/resources/assets/twilightforest/patchouli_books/guide/en_us/entries/bosses/alpha_yeti.json
+++ b/src/main/resources/assets/twilightforest/patchouli_books/guide/en_us/entries/bosses/alpha_yeti.json
@@ -8,7 +8,7 @@
     {
       "type": "entity",
       "entity": "twilightforest:yeti_alpha",
-      "text": "He so baddie but not so bad, he don't got no trophy yeti"
+      "text": "He so baddie but not so bad, he has a trophy now."
     }
   ]
 }


### PR DESCRIPTION
Added a trophy for the alpha yeti to match the rest of the bosses.
Added a separate model of the Alpha Yeti specifically for the trophy since the Alpha Yeti doesn't have a head.
Had to modify the BossVariant enum, the ALPHA_YETI item was renamed to YETI_ALPHA to stop the game from loading the wrong lang file entry.
Changed the advancement icon for killing the Alpha Yeti to its trophy to match the other bosses.